### PR TITLE
Fix build config

### DIFF
--- a/bbb/build/conf/bblayers.conf
+++ b/bbb/build/conf/bblayers.conf
@@ -6,12 +6,12 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  ${HOME}/src/trebletrouble/poky-krogoth/meta \
-  ${HOME}/src/trebletrouble/poky-krogoth/meta-poky \
-  ${HOME}/src/trebletrouble/poky-krogoth/meta-openembedded/meta-networking \
-  ${HOME}/src/trebletrouble/poky-krogoth/meta-openembedded/meta-oe \
-  ${HOME}/src/trebletrouble/poky-krogoth/meta-openembedded/meta-python \
-  ${HOME}/src/trebletrouble/poky-krogoth/meta-qt5 \
-  ${HOME}/src/trebletrouble/bbb/meta-bbb \
+  ${HOME}/trebletrouble/poky-krogoth/meta \
+  ${HOME}/trebletrouble/poky-krogoth/meta-poky \
+  ${HOME}/trebletrouble/poky-krogoth/meta-openembedded/meta-networking \
+  ${HOME}/trebletrouble/poky-krogoth/meta-openembedded/meta-oe \
+  ${HOME}/trebletrouble/poky-krogoth/meta-openembedded/meta-python \
+  ${HOME}/trebletrouble/poky-krogoth/meta-qt5 \
+  ${HOME}/trebletrouble/bbb/meta-bbb \
   "
 


### PR DESCRIPTION
The beagle bone config should point to ${HOME}/trebletrouble
This is the default spot for the source in our vagrant environments. I've made a symlink for my own.
